### PR TITLE
Bump gRPC to 1.81.0; remove zlib libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Cpp gRPC Visual Studio Examples
  Place for holding the Visual Studio Examples source code
- Latest version of gRPC 1.80.0
+ Latest version of gRPC 1.81.0

--- a/vs2019/gRPC_PropertySheet/gRPC.props
+++ b/vs2019/gRPC_PropertySheet/gRPC.props
@@ -158,7 +158,6 @@
         upb_textformat_lib.lib;
         upb_wire_lib.lib;
         utf8_range_lib.lib;
-        zlibd.lib;
         zlibstaticd.lib;
         %(AdditionalDependencies)
         </AdditionalDependencies>
@@ -286,7 +285,6 @@
           upb_textformat_lib.lib;
           upb_wire_lib.lib;
           utf8_range_lib.lib;
-          zlib.lib;
           zlibstatic.lib;
           %(AdditionalDependencies)
       </AdditionalDependencies>
@@ -414,7 +412,6 @@
         upb_textformat_lib.lib;
         upb_wire_lib.lib;
         utf8_range_lib.lib;
-        zlib.lib;
         zlibstatic.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>

--- a/vs2022/gRPC_PropertySheet/gRPC.props
+++ b/vs2022/gRPC_PropertySheet/gRPC.props
@@ -158,7 +158,6 @@
         upb_textformat_lib.lib;
         upb_wire_lib.lib;
         utf8_range_lib.lib;
-        zlibd.lib;
         zlibstaticd.lib;
         %(AdditionalDependencies)
         </AdditionalDependencies>
@@ -286,7 +285,6 @@
           upb_textformat_lib.lib;
           upb_wire_lib.lib;
           utf8_range_lib.lib;
-          zlib.lib;
           zlibstatic.lib;
           %(AdditionalDependencies)
       </AdditionalDependencies>
@@ -414,7 +412,6 @@
         upb_textformat_lib.lib;
         upb_wire_lib.lib;
         utf8_range_lib.lib;
-        zlib.lib;
         zlibstatic.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>


### PR DESCRIPTION
Update README to reference gRPC 1.81.0. Remove dynamic zlib entries (zlib.lib and zlibd.lib) from the VS property sheets for both VS2019 and VS2022, leaving the static zlib variants (zlibstatic.lib / zlibstaticd.lib) in AdditionalDependencies to prefer the static zlib linkage.