### PR TITLE
Update gRPC version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Cpp gRPC Visual Studio Examples
  Place for holding the Visual Studio Examples source code
- Latest version of gRPC 1.81.0
+ Latest version of gRPC 1.81.1


### PR DESCRIPTION
Bump gRPC version reference in README from 1.81.0 to 1.81.1 to reflect the latest release.